### PR TITLE
Remove "bottle :unneeded" as it is deprecated

### DIFF
--- a/Formula/k9s.rb
+++ b/Formula/k9s.rb
@@ -6,7 +6,6 @@ class K9s < Formula
   desc "Kubernetes CLI To Manage Your Clusters In Style!"
   homepage "https://k9scli.io/"
   version "0.24.15"
-  bottle :unneeded
 
   if OS.mac? && Hardware::CPU.intel?
     url "https://github.com/derailed/k9s/releases/download/v0.24.15/k9s_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
Removes deprecated `bottle :unneeded` from the formula. Solves #3 and [#1289 on k9s](https://github.com/derailed/k9s/issues/1289).